### PR TITLE
one-shot!

### DIFF
--- a/.claude/skills/spool/SKILL.md
+++ b/.claude/skills/spool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spool
-description: Manage spool — the in-repo convention for serial multi-session work. Use only when the user types one of `/spool pickup`, `/spool init`, `/spool close`, `/spool commit`, or `/spool status`. Do NOT invoke implicitly on casual references to issue IDs.
+description: Manage spool — the in-repo convention for serial multi-session work. Use only when the user types one of `/spool run`, `/spool pickup`, `/spool init`, `/spool close`, `/spool commit`, or `/spool status`. Do NOT invoke implicitly on casual references to issue IDs.
 ---
 
 # spool
@@ -23,15 +23,18 @@ Route to the matching command playbook in `commands/`:
 
 | User types | Playbook |
 |---|---|
+| `/spool run <ref>` | `commands/run.md` *(recommended default)* |
 | `/spool pickup <ref>` | `commands/pickup.md` |
 | `/spool init <tracker> <id> <slug>` | `commands/init.md` |
 | `/spool close <id>` | `commands/close.md` |
 | `/spool commit` | `commands/commit.md` |
 | `/spool status` | `commands/status.md` |
 
-If the user types `/spool` with no subcommand, list the five subcommands and ask which they want.
+`run` is the sugar — it decides init-vs-pickup from filesystem state. `init` and `pickup` remain as primitives for when the user wants to be explicit.
 
-If the user types `/spool <unknown>`, say so and list the five valid subcommands.
+If the user types `/spool` with no subcommand, list the six subcommands and ask which they want.
+
+If the user types `/spool <unknown>`, say so and list the six valid subcommands.
 
 ## Files and paths
 

--- a/.claude/skills/spool/SKILL.md
+++ b/.claude/skills/spool/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: spool
+description: Manage spool — the in-repo convention for serial multi-session work. Use only when the user types one of `/spool pickup`, `/spool init`, `/spool close`, `/spool commit`, or `/spool status`. Do NOT invoke implicitly on casual references to issue IDs.
+---
+
+# spool
+
+Spool is a filesystem convention inside a project's repo that gives every multi-session piece of work a live working directory, a promotion path into long-lived specs, and a frozen archive at close. This skill automates the conventions the project README spells out.
+
+**Canonical reference:** `./README.md` at the project root describes the convention. When in doubt, re-read it.
+
+## Hard rules — read before every subcommand
+
+1. **Explicit only.** This skill runs only when the user types a `/spool …` command. Never fire from casual mentions like "issue 42" or "#42" in conversation.
+2. **Serial within an issue.** Within one spooled issue: no `git worktree`, no parallel sub-agents via Agent, no "I'll do step 3 and step 5 at once." One thread, one loose end. Different issues can spool concurrently, but inside one issue, work is strictly sequential.
+3. **Confirm before coding.** On pickup, you must surface the issue's README `Next` line and ask the user to confirm it before editing any code. This is the single most important guardrail — the whole methodology fails without it.
+4. **Advisory validation.** If a spool README is missing sections or malformed, point it out but do not refuse to proceed. Schema strictness is a v1 concern.
+5. **Ask, don't assume.** When subcommands need information not in the args (tracker, subsystem, slug), ask the user.
+
+## Routing
+
+Route to the matching command playbook in `commands/`:
+
+| User types | Playbook |
+|---|---|
+| `/spool pickup <ref>` | `commands/pickup.md` |
+| `/spool init <tracker> <id> <slug>` | `commands/init.md` |
+| `/spool close <id>` | `commands/close.md` |
+| `/spool commit` | `commands/commit.md` |
+| `/spool status` | `commands/status.md` |
+
+If the user types `/spool` with no subcommand, list the five subcommands and ask which they want.
+
+If the user types `/spool <unknown>`, say so and list the five valid subcommands.
+
+## Files and paths
+
+All spool state lives under `./spool/` in the project. This skill never writes outside `./spool/` except:
+- The issue branch's own code changes (during pickup's "do one step").
+- Commits and their messages.
+
+Directory shape (from the project README):
+
+```
+./spool/
+  README.md
+  docs/<subsystem>.md
+  agents/decisions.md
+  agents/guardrails.md
+  <tracker>/issue/<id>-<slug>/README.md
+  <tracker>/issue/archive/<id>-<slug>/README.md
+```
+
+Tracker namespace is part of the path (`gh/`, `linear/`, `jira/`, …). Ask the user which tracker when it isn't obvious.
+
+## Templates
+
+When creating or updating files, pull from `./.claude/skills/spool/templates/`:
+
+- `issue-readme.md` — the Done/Next/Deferred/Pitfalls/Open questions template for issue working dirs.
+- `decision-entry.md` — the shape of a single entry appended to `./spool/agents/decisions.md`.
+- `guardrail-entry.md` — the shape of an entry in `./spool/agents/guardrails.md`.
+
+## On any tool's absence
+
+If `./spool/` does not exist yet in the repo, only `/spool init` should create it. For other subcommands, tell the user the project isn't spooled and suggest `/spool init` as the first move.

--- a/.claude/skills/spool/commands/close.md
+++ b/.claude/skills/spool/commands/close.md
@@ -1,0 +1,73 @@
+# /spool close
+
+**Invocation:** `/spool close <id>` (with optional `<tracker>:` prefix on `<id>`).
+
+Walk the five-step promotion ritual. Interactive — ask before each step.
+
+## Steps
+
+### 1. Resolve and sanity-check
+
+Find the issue dir: `find ./spool/<tracker>/issue -maxdepth 1 -type d -name "<id>-*"`. If not found or already under `archive/`, tell the user and stop.
+
+Read the issue README. If `Status:` is not `done`, ask the user to confirm they really want to close anyway.
+
+### 2. Promote to evolving specs
+
+Ask: **which `./spool/docs/<subsystem>.md` file(s) should reflect what shipped?** The user may name an existing file or a new subsystem.
+
+For each named file:
+
+- If it exists, read it. Propose merged content that describes what *is* now (not what's planned).
+- If it's new, draft it from scratch.
+
+Show the proposed spec content to the user for approval. Apply edits once approved.
+
+Principles (from the project README):
+
+- Describe what *is*, not what's planned. Aspirational content stays out.
+- Subsystem granularity — one file per "thing you'd want to read to understand how X works."
+
+### 3. Log decisions
+
+Ask the user: **any key decisions from this issue worth logging?** For each, append an entry to `./spool/agents/decisions.md` using the template:
+
+```
+## <YYYY-MM-DD> — <short headline> (#<id>)
+
+<one-paragraph why: reasoning, alternatives, context>
+```
+
+Insert at the top (newest-first). Use today's date (the actual date, not a placeholder — resolve via `date +%Y-%m-%d`).
+
+### 4. Update guardrails if needed
+
+Ask: **did any agent fail in a way the team should know about?** For each new guardrail, append a line to `./spool/agents/guardrails.md` using the template. Keep it short.
+
+### 5. Archive the issue dir
+
+```bash
+mkdir -p spool/<tracker>/issue/archive
+git mv spool/<tracker>/issue/<id>-<slug> spool/<tracker>/issue/archive/<id>-<slug>
+```
+
+Prefer `git mv` over plain `mv` so git tracks the rename explicitly.
+
+### 6. Commit
+
+Stage everything in `./spool/` and commit:
+
+```
+chore(spool): close #<id>, promote to docs/<subsystem>.md, archive
+
+<one short paragraph on what promoted where>
+
+Spool: spool/<tracker>/issue/archive/<id>-<slug>/README.md
+Refs: #<id>
+```
+
+Ask the user for approval before running `git commit`.
+
+### 7. Report
+
+Summarize what promoted where, what decisions logged, whether any guardrails were added, and the new archive path.

--- a/.claude/skills/spool/commands/commit.md
+++ b/.claude/skills/spool/commands/commit.md
@@ -1,0 +1,89 @@
+# /spool commit
+
+**Invocation:** `/spool commit`
+
+Produce a commit that satisfies the spool commit protocol. Run this when finishing a pickup step (or anywhere you want a spool-shaped commit).
+
+Not a replacement for the user's own commit discipline — a convenience that enforces the protocol.
+
+## Protocol (from the project README)
+
+Every commit on a spooled issue:
+
+- **Subject:** `<type>(<scope>): <what shipped>`.
+- **Body:** one paragraph in the context of the issue. Why this step, what's load-bearing, what tests pass.
+- **Footer:** `Spool: spool/<tracker>/issue/<id>-<slug>/README.md` and `Refs: #<id>`.
+- **Same commit updates the issue's README.md** — `Done` gets the new step, `Next` gets rewritten.
+
+Reading `git log` for an issue should read as a narrative, not a pile of patches.
+
+## Steps
+
+### 1. Identify the active issue
+
+Look for the issue dir matching the current branch:
+
+```bash
+git rev-parse --abbrev-ref HEAD  # current branch
+grep -l "^\*\*Branch:\*\* *$BRANCH" spool/*/issue/*/README.md
+```
+
+If none matches, ask the user which issue this commit belongs to. If they say "none," fall back to a plain conventional commit — but tell them `/spool commit` isn't doing anything special.
+
+### 2. Read the issue README
+
+Capture the current `Done` and `Next` sections.
+
+### 3. Ask the user
+
+- What type (`feat`, `fix`, `chore`, `refactor`, `test`, `docs`) and scope?
+- One-line "what shipped"?
+- One-paragraph "why this step / what's load-bearing / tests"?
+- What is the new `Next`?
+
+Advisory check: if the user's "what shipped" doesn't obviously align with the README's current `Next`, flag it and ask whether the README should be updated first.
+
+### 4. Update the issue README
+
+- Append the just-shipped step to `## Done` as:
+  `- [step N] <what shipped>. Commit: PENDING. Tests: <green|red|n/a>. Verified: <how>.`
+  (The `PENDING` gets replaced with the real sha in step 6.)
+- Replace `## Next` with the user-provided next action.
+
+### 5. Stage and compose the commit
+
+Stage the README update and any code changes the user has told you belong to this step:
+
+```bash
+git add spool/<tracker>/issue/<id>-<slug>/README.md <other files>
+```
+
+Compose the commit message:
+
+```
+<type>(<scope>): <what shipped>
+
+<one-paragraph body>
+
+Spool: spool/<tracker>/issue/<id>-<slug>/README.md
+Refs: #<id>
+```
+
+Show the user the message and stage listing; ask for approval.
+
+### 6. Commit, then backfill the sha
+
+```bash
+git commit -m "$MSG"
+SHA=$(git rev-parse --short HEAD)
+# Replace PENDING with $SHA in the README, amend:
+sed -i "s/Commit: PENDING/Commit: $SHA/" spool/<tracker>/issue/<id>-<slug>/README.md
+git add spool/<tracker>/issue/<id>-<slug>/README.md
+git commit --amend --no-edit
+```
+
+The amend here is limited to the sha backfill on a commit the user just approved — this is the one case where amending is fine. If the user has configured a policy against amends, skip the amend and leave `PENDING` in place with a note.
+
+### 7. Report
+
+Print subject + sha. End.

--- a/.claude/skills/spool/commands/init.md
+++ b/.claude/skills/spool/commands/init.md
@@ -1,0 +1,69 @@
+# /spool init
+
+**Invocation:** `/spool init <tracker> <id> <slug>`
+
+Scaffold a new issue working dir.
+
+## Args
+
+- `<tracker>` — `gh`, `linear`, `jira`, etc. Required. If missing, ask.
+- `<id>` — issue id as used by the tracker (`42`, `ENG-17`). Required. If missing, ask.
+- `<slug>` — short kebab-case name for the work. Required. If missing, suggest one from the tracker title if known, else ask.
+
+## Steps
+
+### 1. Bootstrap `./spool/` if absent
+
+If `./spool/` does not exist, create the baseline layout. Ask the user to confirm once before creating, then:
+
+```bash
+mkdir -p spool/docs spool/agents spool/<tracker>/issue/archive
+[ -f spool/README.md ] || cat > spool/README.md <<'EOF'
+# spool (this project)
+
+Project-local conventions for spool. See the root project README for the spool convention itself.
+EOF
+[ -f spool/agents/decisions.md ] || cat > spool/agents/decisions.md <<'EOF'
+# Decisions
+
+Flat, append-only (newest at top). One entry per key decision. Dated.
+EOF
+[ -f spool/agents/guardrails.md ] || cat > spool/agents/guardrails.md <<'EOF'
+# Guardrails
+
+Agent failure modes — things to stop re-proposing. Short by design.
+EOF
+```
+
+### 2. Refuse if the issue dir already exists
+
+```bash
+dir="spool/<tracker>/issue/<id>-<slug>"
+[ -d "$dir" ] && { echo "already exists: $dir"; exit 1; }
+# Also check archive — refuse if closed-but-archived with this id.
+ls spool/<tracker>/issue/archive/<id>-* 2>/dev/null && { echo "already closed in archive"; exit 1; }
+```
+
+Surface the error to the user; do not overwrite.
+
+### 3. Create the issue dir and seed the README
+
+```bash
+mkdir -p "spool/<tracker>/issue/<id>-<slug>"
+```
+
+Read `./.claude/skills/spool/templates/issue-readme.md`, substitute:
+
+- `{{TITLE}}` — ask the user for a one-line title (or derive from tracker if fetched).
+- `{{TRACKER_URL}}` — ask the user, or construct from tracker+id if a convention is known (e.g., `https://github.com/<owner>/<repo>/issues/<id>` — only if the user confirms the owner/repo).
+- `{{BRANCH}}` — ask the user, or suggest `<type>/<slug>` and let them edit.
+
+Write the result to `spool/<tracker>/issue/<id>-<slug>/README.md`.
+
+### 4. Prompt for Next
+
+Ask the user for the single immediate next concrete action, write it into the `## Next` section.
+
+### 5. Report
+
+Tell the user where the dir was created and what Next is. Do not commit — that's the user's call, and the first real commit will happen during a pickup.

--- a/.claude/skills/spool/commands/pickup.md
+++ b/.claude/skills/spool/commands/pickup.md
@@ -1,0 +1,80 @@
+# /spool pickup
+
+**Invocation:** `/spool pickup <ref>` where `<ref>` is an issue reference (e.g., `#42`, `gh:42`, `linear:ENG-17`).
+
+The pickup protocol. This is the most important subcommand — it's the forcing function that prevents drift between sessions.
+
+## Hard rules — repeated for emphasis
+
+- **Confirm `Next` before editing any code.** Non-negotiable.
+- **Do exactly one step.** End with a commit that updates the issue's `README.md`.
+- **No parallel work.** No `git worktree`, no Agent sub-agents, no "step 3 and step 5 at once." One thread, one loose end.
+
+## Steps
+
+### 1. Resolve the issue dir
+
+Parse `<ref>` into tracker + id. Defaults when ambiguous:
+
+- `#N` or `N` → ask the user which tracker (`gh`, `linear`, etc.) unless only one tracker dir exists under `./spool/`.
+- `gh:N`, `linear:KEY-N`, etc. → tracker is explicit.
+
+Locate the working dir:
+
+```bash
+find ./spool/<tracker>/issue -maxdepth 1 -type d -name "<id>-*" 2>/dev/null
+```
+
+If no match, tell the user the issue isn't spooled and suggest `/spool init <tracker> <id> <slug>`. Do not create anything.
+
+If the match is under `issue/archive/<id>-*/`, tell the user the issue was already closed and ask whether they want to reopen (which is out of scope for this subcommand — they'd need to move it back manually).
+
+### 2. Read the spec
+
+Open the tracker URL recorded in the issue README's `**Spec:**` line. Fetch it only if the user has granted network access (`WebFetch`); otherwise, tell the user you skipped it and ask them to paste any relevant updates.
+
+### 3. Read the issue's `README.md`
+
+This is the source of truth for state. Extract:
+
+- `Status:` — in-progress / blocked / done.
+- `Branch:` — verify it matches current branch; if not, warn the user.
+- `## Done` — what's shipped.
+- `## Next` — the immediate next action. **This is what you'll confirm with the user.**
+- `## Deferred`, `## Pitfalls`, `## Open questions` — load into context.
+
+If any section is missing or malformed, note it but don't refuse to proceed (advisory mode).
+
+### 4. Glance at specs + decisions
+
+Read any `./spool/docs/<subsystem>.md` files mentioned in the issue README or the spec.
+Read the top ~3 entries of `./spool/agents/decisions.md` (newest-first, so the first entries).
+
+### 5. Glance at guardrails
+
+Read `./spool/agents/guardrails.md` in full. It's short by design.
+
+### 6. Confirm `Next` with the user — **STOP HERE**
+
+Surface a short message like:
+
+> Picked up #42 on branch `feat/rate-limit`.
+> README says Next is: **"Add per-user rate limit middleware to api/middleware/rate.ts."**
+> Start there?
+
+Wait for the user's answer. If they redirect, take the redirect as the new Next and do not update the README yet — let the upcoming commit do it.
+
+### 7. Do exactly one step
+
+Implement the confirmed Next. One commit at the end. The commit must:
+
+- Subject: `<type>(<scope>): <what shipped>`.
+- Body: one paragraph in the context of the issue.
+- Footer: `Spool: spool/<tracker>/issue/<id>-<slug>/README.md` and `Refs: #<id>`.
+- Update the issue's `README.md` in the same commit: move the just-finished step to `## Done` with commit sha placeholder (use `HEAD` after commit, or amend with the real sha post-commit if the user permits), and write the next concrete step into `## Next`.
+
+Delegate the commit to `commands/commit.md` conventions.
+
+### 8. Report back
+
+Summarize in one or two sentences: what shipped, what Next now says. End.

--- a/.claude/skills/spool/commands/run.md
+++ b/.claude/skills/spool/commands/run.md
@@ -1,0 +1,75 @@
+# /spool run
+
+**Invocation:** `/spool run <ref>` — the recommended default for starting or continuing work on an issue.
+
+`run` composes `init` and `pickup`. It picks the right branch from filesystem state, so the user doesn't have to remember whether a spool exists yet.
+
+## Arg shapes
+
+All of these are valid:
+
+- `/spool run gh:42` — explicit tracker.
+- `/spool run linear:ENG-17` — explicit tracker.
+- `/spool run 42` — works when only one tracker dir exists under `./spool/`; otherwise ask.
+- `/spool run gh 42 rate-limit` — init-style form, useful on the first run when the slug isn't guessable from the tracker.
+- `/spool run #42` — treat `#N` like the tracker-less short form.
+
+## Hard rules
+
+Same as every other subcommand: explicit-only, serial-within-issue, no parallel work, advisory validation.
+
+`run` inherits `pickup`'s non-negotiable: **confirm Next with the user before editing any code.**
+
+## Decision tree
+
+### 1. Parse the ref
+
+Resolve `<ref>` into tracker + id (+ slug, if provided). Defaults when ambiguous match the rules in `commands/pickup.md` §1.
+
+### 2. Look for the issue dir
+
+```bash
+active=$(find ./spool/<tracker>/issue -maxdepth 1 -type d -name "<id>-*" ! -path '*archive*' 2>/dev/null)
+archived=$(find ./spool/<tracker>/issue/archive -maxdepth 1 -type d -name "<id>-*" 2>/dev/null)
+```
+
+Three cases:
+
+| Active found | Archived found | Action |
+|---|---|---|
+| yes | — | **pickup branch** — delegate to `commands/pickup.md`. |
+| no | yes | Tell the user the issue was already closed. Stop. Do not init. |
+| no | no | **init-then-pickup branch** — see below. |
+
+### 3a. Pickup branch
+
+Delegate directly to `commands/pickup.md` starting from step 2 (read the spec). Everything after is identical.
+
+Edge case — **active dir exists but `## Next` is empty or missing.** This happens when someone ran `init` but never filled Next. Treat it as "partial init":
+
+- Read whatever sections exist.
+- Ask the user for the immediate next concrete action.
+- Write it into `## Next`.
+- Then proceed with pickup step 6 (confirm Next) — yes, even though the user just told you, confirm once to catch any drift between what they said and what got written. Then continue through step 7.
+
+### 3b. Init-then-pickup branch
+
+Delegate to `commands/init.md` for scaffolding (steps 1-4: bootstrap `./spool/`, create issue dir, seed README from template, prompt for Next).
+
+Do NOT stop after init. Immediately flow into `commands/pickup.md` starting from step 6 (the Next-confirmation step) — there's no point re-reading the README you just wrote in steps 1-5, and steps 2-5 of pickup (read spec, glance specs, glance decisions, glance guardrails) may be empty on the first run anyway. Skim them if they exist; skip silently if they don't.
+
+One caveat — on the very first run in a project, `./spool/docs/` and `./spool/agents/*` will be empty. That's fine. Say so to the user in one line so they know there's nothing to glance at, not that you skipped the step.
+
+### 4. Do exactly one step
+
+Same as `pickup` step 7. Commit with the spool commit protocol (delegate to `commands/commit.md` conventions). Update the issue's `README.md` in the same commit.
+
+### 5. Report
+
+Summarize: what the decision tree chose (init-then-pickup vs. pickup), what shipped, what Next now says. One or two sentences.
+
+## When NOT to use run
+
+- When you want to scaffold a dir without starting work yet → use `/spool init`.
+- When you want to explicitly resume an existing dir and be sure init won't fire → use `/spool pickup`.
+- When closing an issue → use `/spool close`. `run` does not close; closing is a distinct act.

--- a/.claude/skills/spool/commands/status.md
+++ b/.claude/skills/spool/commands/status.md
@@ -1,0 +1,46 @@
+# /spool status
+
+**Invocation:** `/spool status`
+
+List active spools across all trackers. Read-only; never edits.
+
+## Steps
+
+### 1. Find active working dirs
+
+```bash
+find ./spool -mindepth 3 -maxdepth 3 -type d -path '*/issue/*' ! -path '*/archive*' ! -name archive
+```
+
+This gives you `./spool/<tracker>/issue/<id>-<slug>/` paths only, excluding the `archive/` dir itself and anything inside it.
+
+If none, report "no active spools" and stop.
+
+### 2. For each dir, extract state
+
+From each `README.md`, pull:
+
+- First line (the `# <Title>` heading).
+- `**Status:**` value.
+- `**Branch:**` value.
+- First non-comment line under `## Next`.
+
+Advisory: if any of these are missing, flag the issue dir as malformed but keep listing.
+
+### 3. Flag suspicious state
+
+- `Status: done` but dir is *not* under `archive/` → flag as "done but not archived — run `/spool close`."
+- `Status: blocked` → flag so the user sees it.
+- Branch recorded in README doesn't exist in `git branch --list` → flag as "branch missing."
+
+### 4. Report
+
+One line per active spool. Keep it terse. Example:
+
+```
+gh/42-rate-limit   in-progress   feat/rate-limit   Next: Add per-user middleware to api/middleware/rate.ts
+gh/51-docs-rewrite done          feat/docs         ⚠ done but not archived — run `/spool close 51`
+linear/ENG-17-...  blocked       fix/eng-17        Next: (awaiting design review)
+```
+
+End.

--- a/.claude/skills/spool/templates/decision-entry.md
+++ b/.claude/skills/spool/templates/decision-entry.md
@@ -1,0 +1,3 @@
+## {{DATE}} — {{HEADLINE}} (#{{ISSUE}})
+
+{{ONE_PARAGRAPH_WHY}}

--- a/.claude/skills/spool/templates/guardrail-entry.md
+++ b/.claude/skills/spool/templates/guardrail-entry.md
@@ -1,0 +1,1 @@
+- **{{AGENT_OR_SHARED}}** — {{RULE_ONE_LINE}}. Why: {{ONE_LINE_REASON}}.

--- a/.claude/skills/spool/templates/issue-readme.md
+++ b/.claude/skills/spool/templates/issue-readme.md
@@ -1,0 +1,22 @@
+# {{TITLE}}
+
+**Spec:** {{TRACKER_URL}}
+**Status:** in-progress
+**Branch:** {{BRANCH}}
+
+## Done
+<!-- One line per completed step, newest at the bottom. Format:
+- [step N] <one line>. Commit: <sha>. Tests: <green|red|n/a>. Verified: <how>.
+-->
+
+## Next
+<!-- The single immediate next concrete action — not the whole roadmap. -->
+
+## Deferred
+<!-- Things cut from this session. One line each: <thing>: <one-line reason>. -->
+
+## Pitfalls
+<!-- Surprises hit during the work — <what> — <how to avoid>. -->
+
+## Open questions
+<!-- Things punted on, needing user input. One per line. -->

--- a/.claude/skills/spool/tests/lib.sh
+++ b/.claude/skills/spool/tests/lib.sh
@@ -80,3 +80,20 @@ spool_archive() {
     mkdir -p "spool/$tracker/issue/archive"
     git mv "spool/$tracker/issue/$id-$slug" "spool/$tracker/issue/archive/$id-$slug"
 }
+
+# Mirrors commands/run.md §Decision tree step 2.
+# Given a tracker + id, print one of: "pickup", "archived", "init".
+# Callers assert on the printed token.
+spool_run_decide() {
+    tracker=$1
+    id=$2
+    active=$(find "./spool/$tracker/issue" -maxdepth 1 -type d -name "$id-*" ! -path '*archive*' 2>/dev/null | head -n1)
+    archived=$(find "./spool/$tracker/issue/archive" -maxdepth 1 -type d -name "$id-*" 2>/dev/null | head -n1)
+    if [ -n "$active" ]; then
+        echo "pickup"
+    elif [ -n "$archived" ]; then
+        echo "archived"
+    else
+        echo "init"
+    fi
+}

--- a/.claude/skills/spool/tests/lib.sh
+++ b/.claude/skills/spool/tests/lib.sh
@@ -1,0 +1,80 @@
+# Shared helpers. Sourced by tests. Not a standalone script.
+# Each test calls `setup_repo` at the top; tmpdir + cd + git init happen there.
+
+setup_repo() {
+    tmp=$(mktemp -d)
+    cd "$tmp"
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git commit --allow-empty -q -m "init"
+    # Find the skill dir relative to this lib.
+    # When sourced, $0 is the test script; resolve SKILL_DIR from its location.
+    SKILL_DIR=$(cd "$(dirname "$TEST_SCRIPT")/.." && pwd)
+    export SKILL_DIR
+}
+
+cleanup_repo() {
+    cd /
+    rm -rf "$tmp"
+}
+
+assert_dir() {
+    [ -d "$1" ] || { echo "expected dir: $1" >&2; exit 1; }
+}
+
+assert_no_dir() {
+    [ ! -d "$1" ] || { echo "expected no dir: $1" >&2; exit 1; }
+}
+
+assert_file() {
+    [ -f "$1" ] || { echo "expected file: $1" >&2; exit 1; }
+}
+
+assert_contains() {
+    grep -qF "$2" "$1" || { echo "expected '$2' in $1" >&2; cat "$1" >&2; exit 1; }
+}
+
+# Re-implement the init subcommand's core scaffolding in shell so we can test
+# the mechanics deterministically. Mirrors commands/init.md steps 1-3.
+spool_init() {
+    tracker=$1
+    id=$2
+    slug=$3
+    title=$4
+    url=$5
+    branch=$6
+
+    mkdir -p spool/docs spool/agents "spool/$tracker/issue/archive"
+    [ -f spool/README.md ] || echo "# spool (this project)" > spool/README.md
+    [ -f spool/agents/decisions.md ] || printf '# Decisions\n\nFlat, append-only (newest at top).\n' > spool/agents/decisions.md
+    [ -f spool/agents/guardrails.md ] || printf '# Guardrails\n\nAgent failure modes.\n' > spool/agents/guardrails.md
+
+    dir="spool/$tracker/issue/$id-$slug"
+    if [ -d "$dir" ]; then
+        echo "already exists: $dir" >&2
+        return 1
+    fi
+    for existing in "spool/$tracker/issue/archive/$id-"*; do
+        [ -e "$existing" ] || continue
+        echo "already closed in archive: $existing" >&2
+        return 1
+    done
+
+    mkdir -p "$dir"
+    tmpl="$SKILL_DIR/templates/issue-readme.md"
+    sed \
+        -e "s|{{TITLE}}|$title|" \
+        -e "s|{{TRACKER_URL}}|$url|" \
+        -e "s|{{BRANCH}}|$branch|" \
+        "$tmpl" > "$dir/README.md"
+}
+
+# Mirrors commands/close.md step 5 — the archive move.
+spool_archive() {
+    tracker=$1
+    id=$2
+    slug=$3
+    mkdir -p "spool/$tracker/issue/archive"
+    git mv "spool/$tracker/issue/$id-$slug" "spool/$tracker/issue/archive/$id-$slug"
+}

--- a/.claude/skills/spool/tests/lib.sh
+++ b/.claude/skills/spool/tests/lib.sh
@@ -1,5 +1,11 @@
 # Shared helpers. Sourced by tests. Not a standalone script.
 # Each test calls `setup_repo` at the top; tmpdir + cd + git init happen there.
+#
+# Resolve SKILL_DIR at source time, BEFORE any cd to a tmp dir. $TEST_SCRIPT
+# may be a relative path, so we must `cd` from the original cwd to get its
+# absolute location.
+SKILL_DIR=$(cd "$(dirname "$TEST_SCRIPT")/.." && pwd)
+export SKILL_DIR
 
 setup_repo() {
     tmp=$(mktemp -d)
@@ -8,10 +14,6 @@ setup_repo() {
     git config user.email "test@example.com"
     git config user.name "Test"
     git commit --allow-empty -q -m "init"
-    # Find the skill dir relative to this lib.
-    # When sourced, $0 is the test script; resolve SKILL_DIR from its location.
-    SKILL_DIR=$(cd "$(dirname "$TEST_SCRIPT")/.." && pwd)
-    export SKILL_DIR
 }
 
 cleanup_repo() {

--- a/.claude/skills/spool/tests/run.sh
+++ b/.claude/skills/spool/tests/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# Entry point. Runs every test_*.sh in this dir in alpha order.
+# Each test is a standalone sh script that exits non-zero on failure.
+# No deps beyond POSIX sh + git + coreutils.
+
+set -eu
+
+here=$(dirname "$0")
+pass=0
+fail=0
+failed_tests=""
+
+for t in "$here"/test_*.sh; do
+    [ -f "$t" ] || continue
+    name=$(basename "$t" .sh)
+    printf '%s ... ' "$name"
+    if sh "$t" >/tmp/spool-test-$$.log 2>&1; then
+        printf 'ok\n'
+        pass=$((pass + 1))
+    else
+        printf 'FAIL\n'
+        fail=$((fail + 1))
+        failed_tests="$failed_tests $name"
+        sed 's/^/    /' /tmp/spool-test-$$.log
+    fi
+    rm -f /tmp/spool-test-$$.log
+done
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+if [ "$fail" -gt 0 ]; then
+    printf 'failed:%s\n' "$failed_tests"
+    exit 1
+fi

--- a/.claude/skills/spool/tests/test_archive_preserves_git_history.sh
+++ b/.claude/skills/spool/tests/test_archive_preserves_git_history.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# Archive move uses git mv so --follow tracks the rename.
+set -eu
+TEST_SCRIPT=$0
+. "$(dirname "$0")/lib.sh"
+
+setup_repo
+trap cleanup_repo EXIT
+
+spool_init gh 42 rate-limit "Add rate limiting" "https://example/issues/42" "feat/rate-limit"
+git add spool
+git commit -q -m "init issue 42"
+
+# Make another commit touching the issue README so git has something to follow.
+echo "- [step 1] sketched the middleware. Commit: deadbee. Tests: n/a. Verified: n/a." \
+    >> spool/gh/issue/42-rate-limit/README.md
+git add spool/gh/issue/42-rate-limit/README.md
+git commit -q -m "step 1"
+
+spool_archive gh 42 rate-limit
+git commit -q -m "archive 42"
+
+assert_no_dir spool/gh/issue/42-rate-limit
+assert_dir spool/gh/issue/archive/42-rate-limit
+assert_file spool/gh/issue/archive/42-rate-limit/README.md
+
+# git log --follow should see pre-rename commits.
+count=$(git log --follow --oneline -- spool/gh/issue/archive/42-rate-limit/README.md | wc -l)
+if [ "$count" -lt 3 ]; then
+    echo "expected >=3 commits via --follow, got $count" >&2
+    git log --follow --oneline -- spool/gh/issue/archive/42-rate-limit/README.md >&2
+    exit 1
+fi

--- a/.claude/skills/spool/tests/test_init_creates_issue_readme.sh
+++ b/.claude/skills/spool/tests/test_init_creates_issue_readme.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+# init creates the issue dir + README, substituting the template placeholders.
+set -eu
+TEST_SCRIPT=$0
+. "$(dirname "$0")/lib.sh"
+
+setup_repo
+trap cleanup_repo EXIT
+
+spool_init gh 42 rate-limit "Add rate limiting" "https://example/issues/42" "feat/rate-limit"
+
+dir=spool/gh/issue/42-rate-limit
+assert_dir "$dir"
+assert_file "$dir/README.md"
+assert_contains "$dir/README.md" "# Add rate limiting"
+assert_contains "$dir/README.md" "**Spec:** https://example/issues/42"
+assert_contains "$dir/README.md" "**Status:** in-progress"
+assert_contains "$dir/README.md" "**Branch:** feat/rate-limit"
+assert_contains "$dir/README.md" "## Done"
+assert_contains "$dir/README.md" "## Next"
+assert_contains "$dir/README.md" "## Deferred"
+assert_contains "$dir/README.md" "## Pitfalls"
+assert_contains "$dir/README.md" "## Open questions"

--- a/.claude/skills/spool/tests/test_init_refuses_archived.sh
+++ b/.claude/skills/spool/tests/test_init_refuses_archived.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+# init refuses if the id already exists in archive (regardless of slug match).
+set -eu
+TEST_SCRIPT=$0
+. "$(dirname "$0")/lib.sh"
+
+setup_repo
+trap cleanup_repo EXIT
+
+mkdir -p spool/gh/issue/archive/42-original-slug
+echo "# Archived" > spool/gh/issue/archive/42-original-slug/README.md
+
+# Baseline init still works for other ids — but 42 must be refused.
+if spool_init gh 42 different-slug "Resurrect" "https://example/issues/42" "feat/x" 2>/dev/null; then
+    echo "expected init to refuse id that exists in archive" >&2
+    exit 1
+fi

--- a/.claude/skills/spool/tests/test_init_refuses_existing.sh
+++ b/.claude/skills/spool/tests/test_init_refuses_existing.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# init refuses to clobber an existing issue dir.
+set -eu
+TEST_SCRIPT=$0
+. "$(dirname "$0")/lib.sh"
+
+setup_repo
+trap cleanup_repo EXIT
+
+spool_init gh 42 rate-limit "Add rate limiting" "https://example/issues/42" "feat/rate-limit"
+
+# Write a marker file so we can detect clobbering.
+echo "do not clobber" > spool/gh/issue/42-rate-limit/marker.txt
+
+# Second init with same id/slug must fail.
+if spool_init gh 42 rate-limit "Another title" "https://example/issues/42" "feat/other" 2>/dev/null; then
+    echo "expected second init to fail" >&2
+    exit 1
+fi
+
+# Marker survived.
+assert_contains spool/gh/issue/42-rate-limit/marker.txt "do not clobber"

--- a/.claude/skills/spool/tests/test_init_scaffolds_baseline.sh
+++ b/.claude/skills/spool/tests/test_init_scaffolds_baseline.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# init creates the baseline spool/ tree on a fresh repo.
+set -eu
+TEST_SCRIPT=$0
+. "$(dirname "$0")/lib.sh"
+
+setup_repo
+trap cleanup_repo EXIT
+
+spool_init gh 42 rate-limit "Add rate limiting" "https://example/issues/42" "feat/rate-limit"
+
+assert_dir spool
+assert_dir spool/docs
+assert_dir spool/agents
+assert_dir spool/gh/issue/archive
+assert_file spool/README.md
+assert_file spool/agents/decisions.md
+assert_file spool/agents/guardrails.md

--- a/.claude/skills/spool/tests/test_run_decides_branch.sh
+++ b/.claude/skills/spool/tests/test_run_decides_branch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# /spool run chooses the right branch (pickup / archived / init) from fs state.
+set -eu
+TEST_SCRIPT=$0
+. "$(dirname "$0")/lib.sh"
+
+setup_repo
+trap cleanup_repo EXIT
+
+# Case 1: nothing exists → init.
+decision=$(spool_run_decide gh 42)
+[ "$decision" = "init" ] || { echo "expected init, got $decision"; exit 1; }
+
+# Case 2: active dir exists → pickup.
+spool_init gh 42 rate-limit "Add rate limiting" "https://example/issues/42" "feat/rate-limit"
+decision=$(spool_run_decide gh 42)
+[ "$decision" = "pickup" ] || { echo "expected pickup, got $decision"; exit 1; }
+
+# Case 3: archived dir exists (no active) → archived.
+git add spool
+git commit -q -m "init 42"
+spool_archive gh 42 rate-limit
+git commit -q -m "archive 42"
+decision=$(spool_run_decide gh 42)
+[ "$decision" = "archived" ] || { echo "expected archived, got $decision"; exit 1; }
+
+# Case 4: fresh id on a spooled repo → init (decision is per-id, not global).
+decision=$(spool_run_decide gh 99)
+[ "$decision" = "init" ] || { echo "expected init for new id, got $decision"; exit 1; }
+
+# Note: "active AND archived both exist" is not a state /spool run or /spool init
+# can produce — init refuses when the id is in archive. Not tested because it
+# would assert on behavior the skill explicitly prevents.

--- a/.claude/skills/spool/tests/test_status_finds_active_only.sh
+++ b/.claude/skills/spool/tests/test_status_finds_active_only.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+# The status find command returns active issue dirs only, not archived ones.
+set -eu
+TEST_SCRIPT=$0
+. "$(dirname "$0")/lib.sh"
+
+setup_repo
+trap cleanup_repo EXIT
+
+spool_init gh 42 rate-limit "Add rate limiting" "https://example/issues/42" "feat/rate-limit"
+spool_init gh 51 docs       "Docs rewrite"      "https://example/issues/51" "feat/docs"
+spool_init linear ENG-17 eng-17 "Payments bug" "https://example/ENG-17" "fix/eng-17"
+git add spool
+git commit -q -m "init three issues"
+
+# Archive one of them.
+spool_archive gh 51 docs
+git commit -q -m "archive 51"
+
+# This mirrors commands/status.md step 1.
+active=$(find ./spool -mindepth 3 -maxdepth 3 -type d -path '*/issue/*' ! -path '*/archive*' ! -name archive | sort)
+
+expected="./spool/gh/issue/42-rate-limit
+./spool/linear/issue/ENG-17-eng-17"
+
+if [ "$active" != "$expected" ]; then
+    echo "active mismatch" >&2
+    printf 'got:\n%s\n' "$active" >&2
+    printf 'want:\n%s\n' "$expected" >&2
+    exit 1
+fi

--- a/.claude/skills/spool/tests/test_template_placeholders_resolved.sh
+++ b/.claude/skills/spool/tests/test_template_placeholders_resolved.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+# After init, the resulting README has no unresolved {{PLACEHOLDER}} tokens.
+set -eu
+TEST_SCRIPT=$0
+. "$(dirname "$0")/lib.sh"
+
+setup_repo
+trap cleanup_repo EXIT
+
+spool_init gh 42 rate-limit "Add rate limiting" "https://example/issues/42" "feat/rate-limit"
+
+if grep -n '{{[A-Z_]*}}' spool/gh/issue/42-rate-limit/README.md; then
+    echo "unresolved placeholders above" >&2
+    exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.envrc
+.env
+.env.*
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -203,16 +203,62 @@ Three surfaces, three jobs, no overlap:
 
 Events flow into state (issue close → promotion). Agents read state before acting. Teams read state to onboard. The repo is the single source of truth; nothing lives in agent-vendor memory files where only one person can see it.
 
+## Install
+
+A Claude Code skill lives under `.claude/skills/spool/`. Two scopes, pick one.
+
+**Per-project (recommended — matches "everything in the repo" ethos):**
+
+```sh
+cd <your-project>
+git clone https://github.com/ahoward/spool /tmp/spool-src
+mkdir -p .claude/skills
+cp -r /tmp/spool-src/.claude/skills/spool .claude/skills/spool
+rm -rf /tmp/spool-src
+```
+
+Commit `.claude/skills/spool/` into the project. The team gets the skill, reviews it, evolves it.
+
+**Personal (available in every project):**
+
+```sh
+git clone https://github.com/ahoward/spool /tmp/spool-src
+mkdir -p ~/.claude/skills
+cp -r /tmp/spool-src/.claude/skills/spool ~/.claude/skills/spool
+rm -rf /tmp/spool-src
+```
+
+**Verify:**
+
+```sh
+sh .claude/skills/spool/tests/run.sh   # or ~/.claude/... for personal scope
+```
+
+All seven tests should pass. In Claude Code, `/spool` should now list the subcommands.
+
+## Commands
+
+All invocations are explicit — the skill never fires on casual mentions of issue IDs.
+
+- `/spool init <tracker> <id> <slug>` — scaffold a new issue working dir.
+- `/spool pickup <ref>` — the pickup protocol. Reads state, confirms Next with you, does one step, commits.
+- `/spool commit` — produce a commit that satisfies the spool commit protocol + updates the issue README in the same commit.
+- `/spool close <id>` — walk the five-step promotion ritual: update specs, log decisions, update guardrails, archive, commit.
+- `/spool status` — list active spools across trackers. Read-only.
+
+See `.claude/skills/spool/SKILL.md` and `.claude/skills/spool/commands/*.md` for the full playbooks.
+
 ## Evolution
 
-This is v0. Likely v1 after dogfooding:
+v0 is Markdown-only: playbooks + templates + inline bash. Advisory validation.
 
-- A `/spool` skill / CLI that automates the pickup protocol.
-- A `/spool init <tracker> <id> <slug>` command that scaffolds the directory from a template.
-- A `/spool close <id>` command that walks the promotion ritual interactively.
+Likely v1 after dogfooding:
+
 - Schema validation on the issue `README.md` so tools can parse it reliably.
+- On-demand portable `bun` binary installed under `.claude/skills/spool/bin/` for logic that outgrows inline shell. No system-runtime assumptions.
+- Release tarball / one-liner installer.
 
-For now, it's discipline. The point of this repo is to lock in the concept before tooling it.
+For now, it's discipline. The point of this repo is to lock in the concept before over-tooling it.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -240,8 +240,14 @@ All seven tests should pass. In Claude Code, `/spool` should now list the subcom
 
 All invocations are explicit — the skill never fires on casual mentions of issue IDs.
 
-- `/spool init <tracker> <id> <slug>` — scaffold a new issue working dir.
-- `/spool pickup <ref>` — the pickup protocol. Reads state, confirms Next with you, does one step, commits.
+**The one you'll use most:**
+
+- `/spool run <ref>` — start or continue work on an issue. If the spool dir doesn't exist yet, scaffolds it; if it does, resumes it. Either way, confirms Next with you, does one step, commits.
+
+**Primitives:**
+
+- `/spool init <tracker> <id> <slug>` — scaffold a new issue working dir without starting work.
+- `/spool pickup <ref>` — resume an existing spool. Fails if no dir exists.
 - `/spool commit` — produce a commit that satisfies the spool commit protocol + updates the issue README in the same commit.
 - `/spool close <id>` — walk the five-step promotion ritual: update specs, log decisions, update guardrails, archive, commit.
 - `/spool status` — list active spools across trackers. Read-only.


### PR DESCRIPTION
## Summary
- Adds the `spool` skill under `.claude/skills/spool/` — Markdown-only, v0 advisory mode, explicit-only triggers (`/spool pickup|init|close|commit|status`).
- Bakes the serial constraint and "confirm Next before coding" guardrail into `SKILL.md` and `commands/pickup.md`.
- Ships POSIX-sh fixture tests under `.claude/skills/spool/tests/` — 7 tests covering scaffold, refuse-on-existing/archived, `git mv` preserves `--follow` history, status enumeration excludes archive, and template placeholder resolution.
- Adds a `.gitignore` protecting `.envrc`, `.env*`, and `.claude/settings.local.json`.

## Test plan
- [ ] `sh .claude/skills/spool/tests/run.sh` — all 7 tests pass.
- [ ] Skim `SKILL.md` — routing table lists all five subcommands; serial-constraint and explicit-only rules are prominent.
- [ ] Read `commands/pickup.md` — step 6 ("confirm Next") is marked non-negotiable.
- [ ] Confirm no secrets in the diff: `.envrc` and `.claude/settings.local.json` are ignored, not committed.
- [ ] Dogfood: run `/spool init gh 1 bootstrap` on a throwaway branch and eyeball the resulting issue README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)