### PR TITLE
feat: spool/playbooks/ as a peer of docs/ and agents/

### DIFF
--- a/.claude/skills/spool/SKILL.md
+++ b/.claude/skills/spool/SKILL.md
@@ -50,6 +50,7 @@ Directory shape (from the project README):
   docs/<subsystem>.md
   agents/decisions.md
   agents/guardrails.md
+  playbooks/<name>.md
   <tracker>/issue/<id>-<slug>/README.md
   <tracker>/issue/archive/<id>-<slug>/README.md
 ```
@@ -63,6 +64,8 @@ When creating or updating files, pull from `./.claude/skills/spool/templates/`:
 - `issue-readme.md` — the Done/Next/Deferred/Pitfalls/Open questions template for issue working dirs.
 - `decision-entry.md` — the shape of a single entry appended to `./spool/agents/decisions.md`.
 - `guardrail-entry.md` — the shape of an entry in `./spool/agents/guardrails.md`.
+
+Playbooks (`./spool/playbooks/<name>.md`) have no template — they are short freeform Markdown. The skill reads them but doesn't generate them; users (or the close ritual) write them.
 
 ## On any tool's absence
 

--- a/.claude/skills/spool/commands/close.md
+++ b/.claude/skills/spool/commands/close.md
@@ -44,6 +44,10 @@ Insert at the top (newest-first). Use today's date (the actual date, not a place
 
 Ask: **did any agent fail in a way the team should know about?** For each new guardrail, append a line to `./spool/agents/guardrails.md` using the template. Keep it short.
 
+### 4.5. Promote any new playbooks
+
+Ask: **is any pattern from this issue worth reusing?** If yes, write or update `./spool/playbooks/<name>.md` — a short recipe (paragraph + numbered list). Skip if nothing recurring came up.
+
 ### 5. Archive the issue dir
 
 ```bash

--- a/.claude/skills/spool/commands/pickup.md
+++ b/.claude/skills/spool/commands/pickup.md
@@ -50,9 +50,11 @@ If any section is missing or malformed, note it but don't refuse to proceed (adv
 Read any `./spool/docs/<subsystem>.md` files mentioned in the issue README or the spec.
 Read the top ~3 entries of `./spool/agents/decisions.md` (newest-first, so the first entries).
 
-### 5. Glance at guardrails
+### 5. Glance at guardrails and playbooks
 
 Read `./spool/agents/guardrails.md` in full. It's short by design.
+
+Grep `./spool/playbooks/*.md` for keywords from the issue title and `## Next`. Read any matching playbook in full. Playbooks are short — a paragraph and a numbered list — so the cost is low and the value is high when a match exists.
 
 ### 6. Confirm `Next` with the user — **STOP HERE**
 

--- a/.claude/skills/spool/commands/run.md
+++ b/.claude/skills/spool/commands/run.md
@@ -58,7 +58,7 @@ Delegate to `commands/init.md` for scaffolding (steps 1-4: bootstrap `./spool/`,
 
 Do NOT stop after init. Immediately flow into `commands/pickup.md` starting from step 6 (the Next-confirmation step) — there's no point re-reading the README you just wrote in steps 1-5, and steps 2-5 of pickup (read spec, glance specs, glance decisions, glance guardrails) may be empty on the first run anyway. Skim them if they exist; skip silently if they don't.
 
-One caveat — on the very first run in a project, `./spool/docs/` and `./spool/agents/*` will be empty. That's fine. Say so to the user in one line so they know there's nothing to glance at, not that you skipped the step.
+One caveat — on the very first run in a project, `./spool/docs/`, `./spool/agents/*`, and `./spool/playbooks/` will be empty. That's fine. Say so to the user in one line so they know there's nothing to glance at, not that you skipped the step.
 
 ### 4. Do exactly one step
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Everything spool-related lives under `./spool/` in your project. Top-level:
   agents/                      # agent-related state (not project state)
     decisions.md               # flat, dated log of key decisions
     guardrails.md              # agent behavioral guardrails — Claude, Gemini, any
+  playbooks/                   # short reusable recipes — "how we do X"
+    <name>.md                  # one playbook per recurring task pattern
   gh/                          # GitHub-tracked issues
     issue/
       <id>-<slug>/             # live working dir
@@ -54,7 +56,7 @@ Everything spool-related lives under `./spool/` in your project. Top-level:
 
 The tracker namespace (`gh/`, `linear/`, etc.) is explicit in the path because not every project uses the same tracker. Issues from multiple trackers coexist without collision.
 
-## The four kinds of files
+## The five kinds of files
 
 ### 1. Issue working dirs — `./spool/<tracker>/issue/<id>-<slug>/`
 
@@ -122,6 +124,18 @@ Why in-repo (not in `~/.claude/.../` or equivalent): team collaboration, multi-a
 
 Format: bullet list grouped by agent (or shared), one line per guardrail, plus a short "why." Short on purpose.
 
+### 5. Playbooks — `./spool/playbooks/<name>.md`
+
+Long-lived. One file per recurring task pattern — "how we add a tracker adapter," "how we close an issue," "how we onboard a new dev." A small, growing skill library scoped to this project.
+
+Read by `pickup` and `run` when the issue title or `Next` mentions a keyword that matches a playbook name. Promoted from issue dirs at close time when a pattern from the work is reusable — same lifecycle as `docs/`, but the unit is a recipe instead of a subsystem.
+
+Principles:
+- One playbook per "thing you'd want a recipe for the next time it comes up."
+- Short — a paragraph or two and a numbered list, not a manual.
+- Plain CommonMark. No front-matter, no parameters. If a playbook needs configuration, it's not a playbook.
+- Promoted, not invented in flight. New playbooks land via the close ritual, where the work that justifies them has already shipped.
+
 ## The promotion ritual (issue close)
 
 When an issue closes, the final PR does, as its last commit:
@@ -129,8 +143,9 @@ When an issue closes, the final PR does, as its last commit:
 1. **Promote to evolving specs.** Update `./spool/docs/<subsystem>.md` to reflect what shipped. Replace or merge sections; this is the *new current truth*.
 2. **Log the decisions.** Append dated entries to `./spool/agents/decisions.md` for any key choices worth remembering.
 3. **Update guardrails if needed.** If an agent failed in a way the team should know about, add to `./spool/agents/guardrails.md`.
-4. **Archive the issue dir.** `mv spool/<tracker>/issue/<id>-<slug>/ spool/<tracker>/issue/archive/<id>-<slug>/`. No tar, no gzip — just move. Git history preserves the rename.
-5. **Commit.** `chore(spool): close #<id>, promote to docs/<subsystem>.md, archive`.
+4. **Promote any new playbooks.** If a pattern from this issue is worth reusing, write or update `./spool/playbooks/<name>.md`. One paragraph + a numbered list, not a manual.
+5. **Archive the issue dir.** `mv spool/<tracker>/issue/<id>-<slug>/ spool/<tracker>/issue/archive/<id>-<slug>/`. No tar, no gzip — just move. Git history preserves the rename.
+6. **Commit.** `chore(spool): close #<id>, promote to docs/<subsystem>.md, archive`.
 
 After merge:
 - Specs carry design truth forward.
@@ -147,7 +162,7 @@ When the user says "do #42" (or any reference to a tracker ID with an active spo
 1. **Read the spec.** Open the issue in the tracker. Understand what's being built.
 2. **Read the issue's `README.md`.** `./spool/<tracker>/issue/<id>-.../README.md` is the source of truth for state. Ignore stale impressions from the spec about progress.
 3. **Glance at relevant specs + decisions.** `./spool/docs/<subsystem>.md` for current truth; `./spool/agents/decisions.md` for recent why-entries.
-4. **Glance at `./spool/agents/guardrails.md`.** Skim for anything relevant before proposing.
+4. **Glance at `./spool/agents/guardrails.md` and `./spool/playbooks/`.** Skim guardrails before proposing; grep playbooks for keywords from the issue title or `Next`.
 5. **Confirm the next action with the user before touching code.** "README says next is step 3 — start there?" Catches drift.
 6. **Do exactly one step.** End with a commit that updates the issue's `README.md`.
 

--- a/spool/gh/issue/9-playbooks-dir/README.md
+++ b/spool/gh/issue/9-playbooks-dir/README.md
@@ -1,0 +1,19 @@
+# Add spool/playbooks/ as a peer of docs/ and agents/
+
+**Spec:** https://github.com/ahoward/spool/issues/9
+**Status:** done
+**Branch:** feat/playbooks
+
+## Done
+- [step 1] Added `spool/playbooks/` as a peer of `spool/docs/` and `spool/agents/`. Updated the project README (Layout block, "five kinds of files" rename, new §5, promotion ritual now has 6 steps with playbooks at step 4, pickup protocol step 4 mentions playbooks). Updated SKILL.md, commands/pickup.md (new step 5 includes playbook grep), commands/run.md (caveat mentions playbooks too), commands/close.md (new step 4.5: promote playbooks). Seeded `spool/playbooks/closing-an-issue.md` as the first playbook — condenses the close ritual to a paragraph + numbered list, demonstrating the shape. 8 tests pass. Commit: 5a294f5. Tests: green. Verified: full suite + read-back of project README and the seed playbook.
+
+## Next
+PR review. Wait for #10 to land first since both touch the issue-README template's surrounding context (no actual conflict since #10 doesn't touch project README, SKILL.md routing, or playbooks-related lines — but worth eyeballing).
+
+## Deferred
+- A `playbooks-index.md` or grep helper. The README's "grep playbooks for keywords" works for the v0 library size; revisit when the dir grows past ~10 playbooks.
+
+## Pitfalls
+
+## Open questions
+- Should the close playbook (`closing-an-issue.md`) duplicate or just point at the project README's promotion ritual? Currently does both — paragraph + steps inline, with a "see also" pointing at the canonical source. Slightly redundant, deliberately so: a playbook should be readable standalone.

--- a/spool/playbooks/closing-an-issue.md
+++ b/spool/playbooks/closing-an-issue.md
@@ -1,0 +1,28 @@
+# Closing an issue
+
+When work on a `spool/<tracker>/issue/<id>-<slug>/` is done, the close ritual carries the lessons forward and freezes the working dir.
+
+The point: nothing useful gets stuck inside the issue. Every reusable thing — current truth, why-it-was-decided, agent failure modes, recurring patterns — moves to its long-lived home. The issue dir then archives intact, addressable forever via git history.
+
+## Steps
+
+1. **Promote to specs.** Update `spool/docs/<subsystem>.md` to describe what *is* now. Skip if the issue didn't shift any subsystem's truth.
+2. **Log decisions.** Append dated entries (newest at top) to `spool/agents/decisions.md` for choices future-work might revisit. Include considered alternatives when relevant.
+3. **Update guardrails.** Append to `spool/agents/guardrails.md` for any failure mode worth not repeating. One short line each.
+4. **Promote playbooks.** If a pattern from this work is reusable, write or update `spool/playbooks/<name>.md`. Short — paragraph + numbered list.
+5. **Archive.** `git mv spool/<tracker>/issue/<id>-<slug> spool/<tracker>/issue/archive/<id>-<slug>`.
+6. **Commit.** `chore(spool): close #<id>, promote to docs/<subsystem>.md, archive`. One paragraph body summarizing what promoted where.
+
+## When to skip a step
+
+- **No spec promotion** if the issue didn't change current truth (e.g., research-only issues).
+- **No decision logged** if no choice was non-obvious or needed explaining later.
+- **No guardrails** if no agent failed in an interesting way.
+- **No playbook** if the work was too one-off to recur.
+
+Skipping is fine. Skipping all five is suspicious — at minimum, the archive happens.
+
+## See also
+
+- `.claude/skills/spool/commands/close.md` — the skill's interactive walkthrough of these steps.
+- Project README §"The promotion ritual (issue close)" — the canonical description.


### PR DESCRIPTION
## Summary

Adds `spool/playbooks/` to the spool convention — Markdown-only Voyager-style skill library. Each playbook is a short recipe ("how we close an issue") that pickup/run can grep for keyword matches.

This is recommendation #5 from the #2 analysis. Bigger than the bundled tweaks in #10 because it's a real convention change — touches the project README, SKILL.md, three command playbooks, and seeds an initial playbook.

## What lands

- Project `README.md` — Layout block adds `playbooks/`, "four kinds of files" → "five kinds" + new §5, promotion ritual gains step 4 ("Promote any new playbooks"), pickup protocol step 4 mentions playbooks alongside guardrails.
- `SKILL.md` — directory shape includes `playbooks/`; templates section notes playbooks are freeform (no template).
- `commands/pickup.md` — step 5 adds playbook grep.
- `commands/run.md` — first-run caveat mentions empty `playbooks/`.
- `commands/close.md` — new step 4.5: "Promote any new playbooks."
- `spool/playbooks/closing-an-issue.md` — first seed playbook demonstrating the shape.

## Test plan

- [ ] `sh .claude/skills/spool/tests/run.sh` — 8 tests still pass (no test changes; this PR doesn't break existing assertions).
- [ ] Read the project README diff — verify "five kinds" is consistent (rename of header + new §5 + ritual step renumbering).
- [ ] Eyeball `spool/playbooks/closing-an-issue.md` — does the shape feel right for future playbooks?
- [ ] Confirm `commands/close.md` has `### 4.5. Promote any new playbooks` between guardrails (4) and archive (5).

## Note

Stack on top of #10? Independent. They don't touch the same files (this PR doesn't change `templates/issue-readme.md`, `templates/decision-entry.md`, or the existing test). Either one can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)