### PR TITLE
fix: close ritual drafts promoted docs from code, scans existing for staleness

### DIFF
--- a/.claude/skills/spool/commands/close.md
+++ b/.claude/skills/spool/commands/close.md
@@ -14,12 +14,27 @@ Read the issue README. If `Status:` is not `done`, ask the user to confirm they 
 
 ### 2. Promote to evolving specs
 
-Ask: **which `./spool/docs/<subsystem>.md` file(s) should reflect what shipped?** The user may name an existing file or a new subsystem.
+This step has three sub-steps in order. Do not skip 2a — it is the single biggest source of bad promoted docs.
+
+#### 2a. Scan existing docs for staleness — BEFORE asking the user
+
+List every file under `./spool/docs/`. Read each one (they are short by convention). For each, check whether what shipped in this issue **supersedes or contradicts** the existing content. Surface any conflicts to the user explicitly:
+
+> `spool/docs/api.md` says "uses iron-session for auth," but issue #75 replaced iron-session with Web Crypto. This file is stale.
+
+Do this **before** asking the open-ended "which files should reflect what shipped?" question. The user may not know what already exists or what just got superseded; the scan is the agent's job, not the user's.
+
+#### 2b. Ask the user — informed by the scan
+
+Ask: **which `./spool/docs/<subsystem>.md` file(s) should reflect what shipped?** Pre-populate the list with anything you flagged as stale in 2a, plus any net-new subsystem the user names.
+
+#### 2c. Draft from code, not from memory
 
 For each named file:
 
-- If it exists, read it. Propose merged content that describes what *is* now (not what's planned).
-- If it's new, draft it from scratch.
+- **Read the actual shipped code first.** Open the files the issue's commits touched. Do not draft from conversation memory or the issue README's `## Done` summaries — both are lossy and framing-dependent.
+- If the file exists, read it too. Propose merged content describing what *is* now.
+- If it's new, draft it from scratch — but still from code, not from conversation.
 
 Show the proposed spec content to the user for approval. Apply edits once approved.
 
@@ -27,6 +42,7 @@ Principles (from the project README):
 
 - Describe what *is*, not what's planned. Aspirational content stays out.
 - Subsystem granularity — one file per "thing you'd want to read to understand how X works."
+- **Draft from code, not from conversation.** Conversation memory is lossy; the source files are authoritative.
 
 ### 3. Log decisions
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Format: bullet list grouped by agent (or shared), one line per guardrail, plus a
 
 When an issue closes, the final PR does, as its last commit:
 
-1. **Promote to evolving specs.** Update `./spool/docs/<subsystem>.md` to reflect what shipped. Replace or merge sections; this is the *new current truth*.
+1. **Promote to evolving specs.** Update `./spool/docs/<subsystem>.md` to reflect what shipped. Replace or merge sections; this is the *new current truth*. **Draft from code, not from conversation memory** — read the actual shipped files. And **scan existing `docs/` for staleness** before drafting; an issue often supersedes content the user has forgotten about.
 2. **Log the decisions.** Append dated entries to `./spool/agents/decisions.md` for any key choices worth remembering.
 3. **Update guardrails if needed.** If an agent failed in a way the team should know about, add to `./spool/agents/guardrails.md`.
 4. **Archive the issue dir.** `mv spool/<tracker>/issue/<id>-<slug>/ spool/<tracker>/issue/archive/<id>-<slug>/`. No tar, no gzip — just move. Git history preserves the rename.

--- a/spool/gh/issue/12-close-ritual-doc-quality/README.md
+++ b/spool/gh/issue/12-close-ritual-doc-quality/README.md
@@ -1,0 +1,19 @@
+# spool close: promoted docs don't reflect actual shipped state
+
+**Spec:** https://github.com/ahoward/spool/issues/12
+**Status:** done
+**Branch:** fix/close-ritual-doc-quality
+
+## Done
+- [step 1] Reshaped `commands/close.md` step 2 (Promote to evolving specs) into three sub-steps in mandatory order: 2a scan existing `spool/docs/` for staleness BEFORE asking the user, 2b ask the user (now informed by the scan), 2c draft from code not from conversation memory. Also threaded the "draft from code" + "scan existing" principles into the project README's promotion ritual step 1, since the README is the canonical description. 8 tests still pass. Commit: 31cac75. Tests: green. Verified: full suite + read-back of close.md and project README.
+
+## Next
+PR review.
+
+## Deferred
+- A test for the new step. There is no shell-driveable assertion ("did the agent read the source files?") — this is a Layer-3 behavioral concern, not a Layer-1 mechanical one. The fix is prose enforcement in the playbook.
+
+## Pitfalls
+
+## Open questions
+- Should `--yolo close` get a hard refusal when `spool/docs/` contains files but the issue's diff doesn't obviously map to any of them? Current `--yolo close` skips promotion silently when no target is named. The new step 2a in interactive mode would catch staleness; under `--yolo` it would still skip. Maybe acceptable since `--yolo close` already trades precision for speed, but worth a follow-up if the failure mode persists.


### PR DESCRIPTION
## Summary

Fixes two real-world close-ritual failures reported in #12 from the vrpsinc/mvp project.

**Failure 1:** close drafted promoted `spool/docs/<subsystem>.md` content from conversation memory rather than reading the actual shipped files. Wrong-on-day-one docs.

**Failure 2:** close asked "which files should reflect what shipped?" without first scanning existing docs for content the issue just superseded. Stale docs survived close.

## What lands

`commands/close.md` step 2 (Promote to evolving specs) reshaped into three mandatory sub-steps in order:

- **2a** — scan existing `spool/docs/` for staleness **before** asking the user. List, skim, flag any file the issue may have superseded.
- **2b** — ask the user, now informed by the scan. Pre-populate the list with anything flagged stale.
- **2c** — draft from **code**, not conversation memory. Read the actual shipped files. Do not rely on the issue README's `## Done` summaries or in-context recall.

Project `README.md` promotion ritual step 1 also gets the two principles threaded in, since the README is the canonical description.

## Test plan

- [ ] `sh .claude/skills/spool/tests/run.sh` — 8 tests still pass (no test changes; this is prose enforcement in the playbook).
- [ ] Read the new `close.md` step 2 — does the 2a/2b/2c order read as mandatory and obvious?
- [ ] Read the README diff — verify the principles land cleanly without bloating the ritual.

## Open question

Should `--yolo close` get a similar treatment when no clear promotion target is named? Currently it silently skips promotion. The interactive 2a scan would catch staleness; `--yolo` would still skip. Captured as an Open question in `spool/gh/issue/12-close-ritual-doc-quality/README.md` rather than addressed here.

## Independence

Stacks cleanly off main. Doesn't touch templates, doesn't touch other command playbooks. Can merge in any order with #4 / #10 / #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)